### PR TITLE
More general use of autoconf to support out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,14 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Build and run autoconf utility
-set(LIBMSR_AUTOCONF ./._autoconf_)
-execute_process(COMMAND gcc -o ._autoconf_ autoconf.c)
-execute_process(COMMAND ${LIBMSR_AUTOCONF})
-# Uncomment for force configuring for a particular architecture
-#set(LIBMSR_TARGET_ARCH 3F)
-#execute_process(COMMAND ${LIBMSR_AUTOCONF} -f ${LIBMSR_TARGET_ARCH})
+set(LIBMSR_AUTOCONF ${CMAKE_BINARY_DIR}/._autoconf_)
+execute_process(COMMAND gcc -o ${LIBMSR_AUTOCONF} ${CMAKE_SOURCE_DIR}/autoconf.c)
+set(LIBMSR_TARGET_ARCH "" CACHE STRING "Force configuring for a particular architecture")
+if (LIBMSR_TARGET_ARCH)
+  execute_process(COMMAND ${LIBMSR_AUTOCONF} -f ${LIBMSR_TARGET_ARCH} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+else()
+  execute_process(COMMAND ${LIBMSR_AUTOCONF} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()
 
 # Headers are in top level include directory
 include_directories(${PROJECT_SOURCE_DIR}/include)

--- a/README
+++ b/README
@@ -41,8 +41,8 @@ The installation depends on a `master.h` file, which defines the offsets for
 several MSRs given a particular architecture (e.g., Sandy Bridge, Ivy Bridge,
 Haswell, etc.). The auto-configuration tool can be forced to use the header
 file of a specific architecture or can auto-detect the architecture. To specify
-a particular architecture, modify the top-level CMakeLists.txt to enable
-`LIBMSR_TARGET_ARCH`, where the argument is in hexadecimal. In the future, we
+a particular architecture, run `cmake` with the option
+`-DLIBMSR_TARGET_ARCH=ARG` where `ARG` is in hexadecimal. In the future, we
 plan to have a set of architecture-specific configuration files that can be
 pre-loaded to CMake to populate the cache.
 


### PR DESCRIPTION
CMake works best (and easiest) when building outside of the source tree.  The patch adds initial support for out-of-source builds while still support in-source builds.  If you plan for an out-of-source builds, it can simplify the CMake configurations, automatic cleanup, and other things like the .gitignore file.