### PR TITLE
doxygen now works for out-of-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 
 add_subdirectory(src)
 add_subdirectory(include)
-
-find_package(Doxygen)
-if (DOXYGEN_FOUND)
-    add_subdirectory(dox)
-endif(DOXYGEN_FOUND)
+add_subdirectory(dox)
 
 add_subdirectory(test)
 add_subdirectory(msrmod)

--- a/dox/CMakeLists.txt
+++ b/dox/CMakeLists.txt
@@ -1,14 +1,15 @@
 find_package(Doxygen)
 if (DOXYGEN_FOUND)
     add_custom_target(doc 
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile 
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
+        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen" VERBATIM
     )
 
     add_custom_target(latex_doc
-        cd ${CMAKE_CURRENT_BINARY_DIR}/latex && make
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex
+        make
+        DEPENDS doc
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/latex
         COMMENT "Building Doxygen Latex documentation" VERBATIM
     )
 endif(DOXYGEN_FOUND)


### PR DESCRIPTION
Documentation can now be generated when using cmake's out-of-source builds.
There's no need to check for doxygen twice - just do it in dox/CMakeLists.txt where it's required.
The latex_doc target also must depend on the doc target.